### PR TITLE
fix issue #11, segfault in shine_BF_freePartHolder

### DIFF
--- a/src/lib/formatbits.c
+++ b/src/lib/formatbits.c
@@ -50,6 +50,9 @@ void shine_formatbits_close(shine_global_config *config)
 {
   int ch, gr;
 
+  if (config->formatbits.side_info.headerPH == NULL) /* Nothing to free */
+          return;
+
   shine_BF_freePartHolder(config->formatbits.side_info.headerPH);
   shine_BF_freePartHolder(config->formatbits.side_info.frameSIPH);
 


### PR DESCRIPTION
config->formatbits.side_info.headerPH and
config->formatbits.side_info.frameSIPH are allocated at the same time
thus checking one of them should be sufficient to ensure that an unsafe
free is not performed. Other solutions would be to check for NULL in
shine_BF_freePartHolder, but this is faster.
