### PR TITLE
Updated Syntax Highlight

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -10,7 +10,7 @@ How to use?
 
 The encoding API should be quite straight forward:
 
-```
+```js
 shine = new Shine({
   samplerate: 44100,
   bitrate: 128,


### PR DESCRIPTION
JS code embedded in the Markdown doesn't have "Syntax Highlighting" enabled. Therefore, to prettify it has been enabled.

See the diffs to get an idea about what has been changed so far in this "pull request".